### PR TITLE
Switch Unity Job to standard Thread for mesh generation

### DIFF
--- a/vr-client/Assets/Samples.meta
+++ b/vr-client/Assets/Samples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c64856e7af5f8b4d8ab4714da3caa38
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vr-client/Assets/Scripts/KinectMeshRenderer.cs
+++ b/vr-client/Assets/Scripts/KinectMeshRenderer.cs
@@ -3,20 +3,97 @@ using System.Collections.Generic;
 using UnityEngine;
 using System;
 using UnityEngine.Profiling;
-using Unity.Jobs;
-using Unity.Collections;
+using System.Threading;
 
-public struct GenerateMeshValuesJob : IJob
+public enum MeshState //The state of async mesh generation
 {
-    public NativeArray<int> depthValues;
-    public int WIDTH;
-    public int HEIGHT;
-    public float edgeSize;
+    HasNewData, // New mesh data that should be applied next frame
+    HasOldData, // No new data (has been applied to renderer already)
+    GeneratingData // Currently generating new mesh data
+}
 
-    public NativeArray<Vector3> vertices;
-    public NativeArray<Vector2> uv;
-    public NativeArray<int> triangles;
-    public NativeArray<int> trianglesUsedLength;
+public class KinectMeshRenderer : MonoBehaviour
+{
+    [Tooltip("Width of kinect data. Default: 640")]
+    public int WIDTH = 640;
+
+    [Tooltip("Height of kinect data. Default: 480")]
+    public int HEIGHT = 480;
+
+    [Tooltip("The minimum raw difference to a neighbouring depth value that is considered a split edge")]
+    public float edgeSize = 24;
+
+    [Tooltip("Shader to use for procedural mesh. If not specified the Unlit/Transparent shader will be used")]
+    public Shader shader;
+
+    MeshFilter meshFilter; // This object's MeshFilter component
+    MeshRenderer meshRenderer; // This object's MeshRenderer component
+    Mesh mesh; // The mesh to be rendered
+
+    Texture2D texture; // Texture of RGB data
+    int mainTextureId; // The ID representing a main texture (used to set new textures to the kinect mesh's material)
+
+    MeshState meshState; //The state of async mesh generation
+    Vector3[] vertices;
+    Vector2[] uvs;
+    int[] triangles;
+
+    public void asyncGenerateMesh(int[] depthValues)
+    {
+        vertices = new Vector3[WIDTH * HEIGHT];
+        uvs = new Vector2[WIDTH * HEIGHT];
+        List<int> trianglesList = new List<int>();
+
+        Profiler.BeginSample("Get vertices");
+        for (int i = 0; i < WIDTH * HEIGHT; i++)
+        {
+            int x = i % WIDTH;
+            int y = i / WIDTH;
+            vertices[i] = depthToWorld(x, y, depthValues[i]);
+        }
+        Profiler.EndSample();
+
+        Profiler.BeginSample("Get uv and triangles");
+        List<int> meshTrianglesList = new List<int>();
+        for (int x = 0; x < WIDTH - 1; x++)
+        {
+            for (int y = 0; y < HEIGHT - 1; y++)
+            {
+                int v1 = x + y * WIDTH;
+                uvs[v1] = new Vector2(
+                    Math.Max(Math.Min((1.07777777777777778f * x - 16.6666666f) / WIDTH, 1f), 0f),
+                    Math.Min((0.9142857142857143f * y + 46.7142857f) / HEIGHT, 1f)  //y - 0.08571428571428572f * y + 46.7142857f
+                );
+
+                int v2 = v1 + 1;
+                int v3 = v1 + WIDTH;
+
+                if (validPoint(v2, depthValues) && validPoint(v3, depthValues))
+                {
+                    int v4 = v3 + 1;
+                    if (validPoint(v1, depthValues))
+                    {
+                        trianglesList.Add(v1);
+                        trianglesList.Add(v3);
+                        trianglesList.Add(v2);
+                    }
+                    if (validPoint(v4, depthValues))
+                    {
+                        trianglesList.Add(v2);
+                        trianglesList.Add(v3);
+                        trianglesList.Add(v4);
+                    }
+                }
+            }
+        }
+        Profiler.EndSample();
+
+        Profiler.BeginSample("convert triangle List");
+        triangles = trianglesList.ToArray();
+        Profiler.EndSample();
+
+        meshState = MeshState.HasNewData;
+    }
 
     /*
     * Converts a raw kinect depth reading to the depth in meters
@@ -53,101 +130,12 @@ public struct GenerateMeshValuesJob : IJob
      * Determines if a point has a valid depth reading
      * (Valid depth reading and not part of an edge)
      */
-    bool validPoint(int index, NativeArray<int> depthValues)
+    bool validPoint(int index, int[] depthValues)
     {
         return depthValues[index] < 2047;/* && (
             (index % WIDTH == WIDTH - 1 || Math.Abs(depthValues[index] - depthValues[index + 1]) < edgeSize) &&
             (index / WIDTH == HEIGHT - 1 || Math.Abs(depthValues[index] - depthValues[index + WIDTH]) < edgeSize));*/
     }
-
-    public void Execute()
-    {
-        Profiler.BeginSample("Get vertices");
-        for (int i = 0; i < WIDTH * HEIGHT; i++)
-        {
-            int x = i % WIDTH;
-            int y = i / WIDTH;
-            vertices[i] = depthToWorld(x, y, depthValues[i]);
-        }
-        Profiler.EndSample();
-
-        Profiler.BeginSample("Get uv and triangles");
-        List<int> meshTrianglesList = new List<int>();
-        for (int x = 0; x < WIDTH - 1; x++)
-        {
-            for (int y = 0; y < HEIGHT - 1; y++)
-            {
-                int v1 = x + y * WIDTH;
-                uv[v1] = new Vector2(
-                    Math.Max(Math.Min((1.07777777777777778f * x - 16.6666666f) / WIDTH, 1f), 0f),
-                    Math.Min((0.9142857142857143f * y + 46.7142857f) / HEIGHT, 1f)  //y - 0.08571428571428572f * y + 46.7142857f
-                );
-
-                int v2 = v1 + 1;
-                int v3 = v1 + WIDTH;
-
-                if (validPoint(v2, depthValues) && validPoint(v3, depthValues))
-                {
-                    int v4 = v3 + 1;
-                    if (validPoint(v1, depthValues))
-                    {
-                        meshTrianglesList.Add(v1);
-                        meshTrianglesList.Add(v3);
-                        meshTrianglesList.Add(v2);
-
-                    }
-                    if (validPoint(v4, depthValues))
-                    {
-                        meshTrianglesList.Add(v2);
-                        meshTrianglesList.Add(v3);
-                        meshTrianglesList.Add(v4);
-
-                    }
-                }
-            }
-        }
-        Profiler.EndSample();
-
-        Profiler.BeginSample("convert triangle List");
-        trianglesUsedLength[0] = meshTrianglesList.Count;
-        for (int i = 0; i < meshTrianglesList.Count; i++)
-        {
-            triangles[i] = meshTrianglesList[i];
-        }
-        Profiler.EndSample();
-    }
-}
-
-public class KinectMeshRenderer : MonoBehaviour
-{
-    [Tooltip("Width of kinect data. Default: 640")]
-    public int WIDTH = 640;
-
-    [Tooltip("Height of kinect data. Default: 480")]
-    public int HEIGHT = 480;
-
-    [Tooltip("The minimum raw difference to a neighbouring depth value that is considered a split edge")]
-    public float edgeSize = 24;
-
-    [Tooltip("Shader to use for procedural mesh. If not specified the Unlit/Transparent shader will be used")]
-    public Shader shader;
-
-    MeshFilter meshFilter; // This object's MeshFilter component
-    MeshRenderer meshRenderer; // This object's MeshRenderer component
-    Mesh mesh; // The mesh to be rendered
-
-    Vector3[] meshVertices; // Vertices representing points in space for depth values
-    Vector2[] meshUvs; // UV mapping of texture onto mesh
-    Texture2D texture; // Texture of RGB data
-    int mainTextureId;
-
-    JobHandle meshValJobHandle;
-    NativeArray<int> trianglesUsedLength;
-    NativeArray<int> trianglesNativeArray;
-    NativeArray<Vector2> uvNativeArray;
-    NativeArray<Vector3> verticesNativeArray;
-    NativeArray<int> depthNativeArray;
-    bool recievedVisionData;
 
     /*
      * Updates the rotation of the kinect mesh
@@ -161,41 +149,12 @@ public class KinectMeshRenderer : MonoBehaviour
      */
     public void updateVision(Texture2D newTexture, int[] newDepthValues)
     {
-        if ( meshValJobHandle.IsCompleted ) { // Only accept a new frame if the last one is finished processing. Note: Unity makes sure meshValJobHandle can't be null
+        if (meshState == MeshState.HasOldData) { // Only accept a new frame if the last one is finished processing. Note: Unity makes sure meshValJobHandle can't be null
+            meshState = MeshState.GeneratingData;
             Profiler.BeginSample("Begin update vision job");
-
-            meshValJobHandle.Complete(); // Must be called to prevent warning
-
-            // Dispose of old shared mem if it was created
-            if (trianglesUsedLength.IsCreated)
-            {
-                trianglesUsedLength.Dispose();
-                depthNativeArray.Dispose();
-                trianglesNativeArray.Dispose();
-                uvNativeArray.Dispose();
-                verticesNativeArray.Dispose();
-            }
-
-            GenerateMeshValuesJob meshValJob = new GenerateMeshValuesJob();// Define a generate mesh job
-            depthNativeArray = new NativeArray<int>(newDepthValues, Allocator.TempJob); // the 11 bit depth values (input)
-            meshValJob.depthValues = depthNativeArray;
-
-            trianglesNativeArray = new NativeArray<int>((WIDTH - 1) * (HEIGHT - 1) * 6, Allocator.TempJob); // Holds triangle data. Note: doesn't have to use it's full length
-            meshValJob.triangles = trianglesNativeArray;
-            trianglesUsedLength = new NativeArray<int>(1, Allocator.TempJob); // Holds actual length of returned triangle data
-            meshValJob.trianglesUsedLength = trianglesUsedLength;
-            uvNativeArray = new NativeArray<Vector2>(WIDTH * HEIGHT, Allocator.TempJob); // Holds uv wieghts for texture alignment
-            meshValJob.uv = uvNativeArray;
-            verticesNativeArray = new NativeArray<Vector3>(WIDTH * HEIGHT, Allocator.TempJob); // Holds the positions of the vertices
-            meshValJob.vertices = verticesNativeArray;
-            meshValJob.WIDTH = WIDTH;
-            meshValJob.HEIGHT = HEIGHT;
-            meshValJob.edgeSize = edgeSize;
-            meshValJobHandle = meshValJob.Schedule(); // Start running job
-
+            Thread thread = new Thread(() => asyncGenerateMesh(newDepthValues));
+            thread.Start();
             texture = newTexture; //Prepare texture for application once mesh is ready
-            recievedVisionData = true;
-
             Profiler.EndSample();
         }
         
@@ -203,8 +162,8 @@ public class KinectMeshRenderer : MonoBehaviour
 
     void Awake()
     {
+        meshState = MeshState.HasOldData;
         mainTextureId = Shader.PropertyToID("_MainTex");
-        recievedVisionData = false;
         meshRenderer = transform.GetChild(0).GetComponent<MeshRenderer>();
         meshFilter = transform.GetChild(0).GetComponent<MeshFilter>();
         if (!shader)
@@ -217,28 +176,28 @@ public class KinectMeshRenderer : MonoBehaviour
     void Start()
     {
         // Create mesh's needed arrays
-        meshVertices = new Vector3[WIDTH * HEIGHT];
-        meshUvs = new Vector2[WIDTH * HEIGHT];
-        int[] meshTriangles = new int[(WIDTH - 1) * (HEIGHT - 1) * 6];
+        vertices = new Vector3[WIDTH * HEIGHT];
+        uvs = new Vector2[WIDTH * HEIGHT];
+        triangles = new int[(WIDTH - 1) * (HEIGHT - 1) * 6];
 
         // Create grid of vertices and evenly distributed UV texture points
         for (int i = 0; i < WIDTH*HEIGHT; i++)
         {
             int x = i % WIDTH;
             int y = i / WIDTH;
-            meshUvs[i] = new Vector2(
+            uvs[i] = new Vector2(
                 Math.Max((float)(x) / WIDTH, 0f), // - 22
                 Math.Min((float)(y) / HEIGHT, 1f) // + 24
             );
-            meshVertices[i] = new Vector3((float)x / WIDTH, (float)y / WIDTH, 0f);
+            vertices[i] = new Vector3((float)x / WIDTH, (float)y / WIDTH, 10f);
         }
 
         // Apply geometry values to mesh
         mesh = new Mesh();
         mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
-        mesh.vertices = meshVertices;
-        mesh.triangles = meshTriangles;
-        mesh.uv = meshUvs;
+        mesh.vertices = vertices;
+        mesh.triangles = triangles;
+        mesh.uv = uvs;
         meshFilter.mesh = mesh;
         mesh.bounds = new Bounds(new Vector3(0f, 0f, 0f), new Vector3(99f, 99f, 99f));
         meshRenderer.material.shader = shader; // Apply shader to handle transparency
@@ -247,26 +206,17 @@ public class KinectMeshRenderer : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if(recievedVisionData && meshValJobHandle.IsCompleted) // Has recieved data
+        if(meshState == MeshState.HasNewData) // Has recieved data
         {
             Profiler.BeginSample("Update kinect mesh renderer");
-            meshValJobHandle.Complete(); // Prevent warning
-            mesh.vertices = verticesNativeArray.ToArray();
+            mesh.vertices = vertices;
+            mesh.triangles = triangles;
 
-            int[] trianglesArray = new int[trianglesUsedLength[0]]; // Trim and assign new triangles data
-            Array.Copy(trianglesNativeArray.ToArray(), trianglesArray, trianglesUsedLength[0]);
-            mesh.triangles = trianglesArray; 
-
-            mesh.uv = uvNativeArray.ToArray();
+            mesh.uv = uvs;
             meshRenderer.material.SetTexture(mainTextureId, texture);
             meshFilter.mesh = mesh;
 
-            trianglesUsedLength.Dispose();
-            depthNativeArray.Dispose();
-            trianglesNativeArray.Dispose();
-            uvNativeArray.Dispose();
-            verticesNativeArray.Dispose();
-            recievedVisionData = false;
+            meshState = MeshState.HasOldData;
             Profiler.EndSample();
         }
     }


### PR DESCRIPTION
Because Unity Jobs don't like to take a noticable amount of frames to finish